### PR TITLE
Regras

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,15 @@ A API recebe valores de carater monetário, data e hora, e tipos de pagamento qu
 
 Segue uma tabela com os principais valores que foram normalizados e seus tratamentos:
 
-| Valor Recebido         | Valor Retornado | Tratamento Aplicado                                                             |
-|------------------------|-----------------|---------------------------------------------------------------------------------|
-| Valor (String)         | String          | Remoção de vírgula e conversão para BigDecimal                                  |
-| DataHora (String)      | String          | Conversão de String para LocalDateTime utilizando formato "dd/MM/yyyy HH:mm:ss" |
-| TipoPagamento (String) | String          | Normalização para enum TipoPagamento                                            |
+| Valor Recebido             | Valor Retornado | Tratamento Aplicado                                                                                                   |
+|----------------------------|-----------------|-----------------------------------------------------------------------------------------------------------------------|
+| Valor (String)             | String          | Remoção de vírgula e conversão para BigDecimal                                                                        |
+| DataHora (String)          | String          | Conversão de String para LocalDateTime utilizando formato "dd/MM/yyyy HH:mm:ss"                                       |
+| TipoPagamento (String)     | String          | Normalização para enum TipoPagamento                                                                                  |
+| Parcelas (String)          | Integer         | Conversão de String para Integer                                                                                      |
+| ID (transacao) (String)    | String          | Validação de formato e uso como ID externo, sem persistir como <br/> ID interno e precisa conter 15 digitos numéricos |
+| nsu (String)               | String          | Geração de NSU único com 10 dígitos numéricos randômicos, garantindo unicidade no banco de dados                      |
+| codigoAutorizacao (String) | String          | Geração de código de autorização único com 9 dígitos numéricos randômicos, garantindo unicidade no banco de dados     |
 
 
 ## Funcionalidade
@@ -154,6 +158,10 @@ Regras aplicadas:
 - Pagamentos acima de determinado valor são negados (10000.00)
 - Cada pagamento possui NSU único
 - Cada pagamento possui código de autorização único
+- O ID recebido no payload é tratado como um ID externo e não é utilizado como chave primária no banco de dados, para evitar problemas de duplicidade e garantir a integridade dos dados.
+- O ID interno é gerado automaticamente pelo banco de dados e utilizado para identificação única de cada pagamento registrado.
+- O ID externo é persistido como um campo separado na entidade de pagamento, permitindo a associação entre o pagamento registrado e o ID fornecido no payload, sem comprometer a integridade do banco de dados.
+- O Tratamento para ID externo permite apenas a aceitação de IDs numéricos com 15 dígitos, garantindo um formato consistente para os IDs externos e evitando problemas de formatação ou validação.
 
 #### Estorno
 Responsável por realizar o estorno de um pagamento previamente registrado.

--- a/src/main/java/com/toolschallenge/toolschallenge/pagamento/api/dto/PagamentoRequestDto.java
+++ b/src/main/java/com/toolschallenge/toolschallenge/pagamento/api/dto/PagamentoRequestDto.java
@@ -9,7 +9,9 @@ public record PagamentoRequestDto(
         @NotNull @Valid Transacao transacao
 ) {
     public record Transacao(
+            // deve conter apenas números, sem espaços ou caracteres especiais, e ter exatamente 16 dígitos
             @NotBlank String cartao,
+            @Pattern(regexp = "^\\d{15}$", message = "ID deve conter exatamente 15 dígitos numéricos")
             @NotBlank String id,
             @NotNull @Valid Descricao descricao,
             @NotNull @Valid FormaPagamento formaPagamento

--- a/src/main/java/com/toolschallenge/toolschallenge/pagamento/domain/valueobejct/Transacao.java
+++ b/src/main/java/com/toolschallenge/toolschallenge/pagamento/domain/valueobejct/Transacao.java
@@ -14,10 +14,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Transacao {
-    @Column(name = "cartao", nullable = false)
+    @Column(name = "cartao", nullable = false, length = 16)
     private String cartao;
 
-    @Column(name = "transacao_id", nullable = false, unique = true)
+    @Column(name = "transacao_id", nullable = false, unique = true, length = 15)
     private String id;
 
     @Embedded

--- a/src/main/resources/db/migration/V3__add_lenght_limit.sql
+++ b/src/main/resources/db/migration/V3__add_lenght_limit.sql
@@ -1,0 +1,5 @@
+-- Reduz tamanho do campo transacao_id para 15 caracteres
+-- Necessário após padronização do identificador da transação
+
+ALTER TABLE pagamento
+ALTER COLUMN transacao_id TYPE VARCHAR(15);


### PR DESCRIPTION
Criação de regra adicional para permitir apenas 15 dígitos numéricos de ID em transação. 

Projeto rodando:
<img width="1649" height="72" alt="image" src="https://github.com/user-attachments/assets/e26cfd23-2a2d-40d5-b9ba-1620b212ee56" />

Todos os testes passando: 
<img width="1079" height="140" alt="image" src="https://github.com/user-attachments/assets/820981fd-122c-45ae-88ba-8e30de353dbf" />


(Não houve alteração em lógica)